### PR TITLE
Add backend for AirScan (eSCL) and WSD scanners

### DIFF
--- a/sane-backends/airscan.yaml
+++ b/sane-backends/airscan.yaml
@@ -1,0 +1,10 @@
+name: sane-airscan
+buildsystem: meson
+sources:
+  - type: git
+    url: https://github.com/alexpevzner/sane-airscan.git
+    commit: 053f5654cd4d16f077fe5cb40d32004aaa321462
+    tag: 0.99.27
+    x-checker-data:
+      type: git
+      tag-pattern: ^([\d.]+)$

--- a/sane-backends/sane-backends.yaml
+++ b/sane-backends/sane-backends.yaml
@@ -101,5 +101,6 @@ modules:
       - grep '^[[:blank:]]*localhost[[:blank:]]*$' "${FLATPAK_DEST}/etc/sane.d/net.conf" || echo 'localhost' >> "${FLATPAK_DEST}/etc/sane.d/net.conf";
       - grep '^[[:blank:]]*net[[:blank:]]*$' "${FLATPAK_DEST}/etc/sane.d/dll.conf" || echo 'net' >> "${FLATPAK_DEST}/etc/sane.d/dll.conf";
   - hpaio.yaml
+  - airscan.yaml
 cleanup:
   - '*.la'


### PR DESCRIPTION
Goes on top of https://github.com/flathub/org.gnome.OCRFeeder/pull/26 and https://github.com/flathub/org.gnome.OCRFeeder/pull/27