### PR TITLE
Updating Gnome Runtime

### DIFF
--- a/enchant.yaml
+++ b/enchant.yaml
@@ -5,8 +5,8 @@ config-opts:
   - --with-myspell-dir=/app/share/myspell
 sources:
   - type: archive
-    url: https://github.com/AbiWord/enchant/releases/download/enchant-1-6-1/enchant-1.6.1.tar.gz
-    sha256: bef0d9c0fef2e4e8746956b68e4d6c6641f6b85bd2908d91731efb68eba9e3f5
+    url: https://github.com/AbiWord/enchant/archive/refs/tags/enchant-1-6-1.tar.gz
+    sha256: ed2b11211a571ab5f963debf4c3bf3fc46541bb9cbb441b2997bd871ba8618d4
   - type: shell
     commands:
       - cp -p /usr/share/automake-*/config.{sub,guess} .;

--- a/enchant2.yaml
+++ b/enchant2.yaml
@@ -5,8 +5,8 @@ config-opts:
   - --with-hunspell-dir=/app/share/hunspell
 sources:
   - type: archive
-    url: https://github.com/AbiWord/enchant/releases/download/v2.2.15/enchant-2.2.15.tar.gz
-    sha256: 3b0f2215578115f28e2a6aa549b35128600394304bd79d6f28b0d3b3d6f46c03
+    url: https://github.com/AbiWord/enchant/archive/refs/tags/v2.2.15.tar.gz
+    sha256: 85295934102a4ab94f209cbc7c956affcb2834e7a5fb2101e2db436365e2922d
   # https://src.fedoraproject.org/rpms/enchant2/blob/63318bc1310b50b0f20cec54886872c7394db1e8/f/enchant_aspell.patch
   - type: patch
     path: enchant2-2.2.8-aspell.patch

--- a/org.gnome.OCRFeeder.yaml
+++ b/org.gnome.OCRFeeder.yaml
@@ -1,12 +1,12 @@
 app-id: org.gnome.OCRFeeder
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: ocrfeeder
 finish-args:
   # X11 + XShm access
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   # Wayland access
   - --socket=wayland
   # Filesystem access


### PR DESCRIPTION
## Summary of Changes
- Updating Gnome Runtime to version 47 from [deprecated](https://release.gnome.org/calendar/) version 44. It closes issues #31 and #33.
- Updating  permissions according to [guidelines for Wayland](https://docs.flatpak.org/en/latest/sandbox-permissions.html). Using `fallback-x11`.