### PR TITLE
Update djvulibre

### DIFF
--- a/org.gnome.OCRFeeder.yaml
+++ b/org.gnome.OCRFeeder.yaml
@@ -247,8 +247,8 @@ modules:
           - --enable-threads
         sources:
           - type: archive
-            url: https://downloads.sourceforge.net/djvu/djvulibre-3.5.28.tar.gz
-            sha256: fcd009ea7654fde5a83600eb80757bd3a76998e47d13c66b54c8db849f8f2edc
+            url: https://downloads.sourceforge.net/djvu/djvulibre-3.5.29.tar.gz
+            sha256: d3b4b03ae2bdca8516a36ef6eb27b777f0528c9eda26745d9962824a3fdfeccf
           # https://src.fedoraproject.org/rpms/djvulibre/blob/ecae4ffecbf52962c24f242361072a57f9385ae0/f/djvulibre-3.5.27-export-file.patch
           - type: patch
             path: patches/djvulibre-3.5.27-export-file.patch


### PR DESCRIPTION
See https://github.blog/security/vulnerability-research/cve-2025-53367-an-exploitable-out-of-bounds-write-in-djvulibre/